### PR TITLE
feat: add rust-either

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -802,3 +802,7 @@ repos:
     group: deepin-sysdev-team
     info: Discus aims to make df prettier, with features such as color, graphs, and smart formatting of numbers.
 
+  - repo: rust-either
+    group: deepin-sysdev-team
+    info: This metapackage enables feature "serde" for the Rust either crate, by pulling in any additional dependencies needed by that feature.
+


### PR DESCRIPTION
Log: This metapackage enables feature "serde" for the Rust either crate, by pulling in any additional dependencies needed by that feature.
Issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/64
Tast: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/5
Influence: rust-either would be added