### PR TITLE
feat: add fonts-intel-one-mono

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -746,10 +746,6 @@ repos:
     group: deepin-sysdev-team
     info: convert a dictionary file type to another dictionary file type
 
-  - repo: intel-one-mono
-    group: deepin-sysdev-team
-    info: an expressive monospaced font family that’s built with clarity, legibility, and the needs of developers in mind.
-    
   - repo: rust-bitflags
     group: deepin-sysdev-team
     info: 'source for the Rust bitflags crate'
@@ -798,3 +794,7 @@ repos:
     group: deepin-sysdev-team
     info: Rust bindings for Windows API functions.
 
+  - repo: fonts-intel-one-mono
+    group: deepin-sysdev-team
+    info: an expressive monospaced font family that’s built with clarity, legibility, and the needs of developers in mind.
+    


### PR DESCRIPTION
an expressive monospaced font family that’s built with clarity, legibility, and the needs of developers in mind.

Log: add fonts-intel-one-mono
Issue: [https://github.com/deepin-community/sig-deepin-sysdev-team/issues/55](url)
Task: [https://github.com/deepin-community/sig-deepin-sysdev-team/issues/4](url)
Influence: fonts intel-one-mono would be added
