### PR TITLE
feat: add rust-log

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -813,8 +813,12 @@ repos:
   - repo: rust-scopeguard
     group: deepin-sysdev-team
     info: Defines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as shorthands for guards with one of the implemented strategies.
-    
+  
   - repo: rust-minimal-lexical
     group: deepin-sysdev-team
     info: This package contains the source for the Rust minimal-lexical crate, packaged by debcargo for use with cargo and dh-cargo.
+
+  - repo: rust-log
+    group: deepin-sysdev-team
+    info: This package contains the source for the Rust log crate, packaged by debcargo for use with cargo and dh-cargo.
 


### PR DESCRIPTION
This package contains the source for the Rust log crate, packaged by debcargo for use with cargo and dh-cargo.

Log: add rust-log
Issue: [https://github.com/deepin-community/sig-deepin-sysdev-team/issues/55](https://github.com/deepin-community/Repository-Manager/pull/url)