### PR TITLE
feat: add rust-cexpr, rust-lexical-core

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -858,3 +858,11 @@ repos:
     group: deepin-sysdev-team
     info: HTML to PostScript converter
 
+  - repo: add rust-cexpr
+    group: deepin-sysdev-team
+    info: This package contains the source for the Rust cexpr crate.
+
+  - repo: rust-lexical-core
+    group: deepin-sysdev-team
+    info: This package contains the source for the Rust lexical-core crate.
+    


### PR DESCRIPTION
This package contains the source for the Rust cexpr crate.

Log: add rust-cexpr
Issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/75