### PR TITLE
feat: add rust-clap, rust-clap-lex, rust-termcolor, rust-os-str-bytes

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -834,3 +834,23 @@ repos:
     group: deepin-sysdev-team
     info: Rust target for the Windows operating system, used for building Rust applications that run on 64-bit Windows systems using the GNU toolchain.
 
+  - repo: rust-clap
+    group: deepin-sysdev-team
+    info: Rust Command Line Argument Parser.
+
+  - repo: rust-clap-lex
+    group: deepin-sysdev-team
+    info: Minimal, flexible command line parser.
+
+  - repo: rust-termcolor
+    group: deepin-sysdev-team
+    info: Simple cross platform library for writing colored text to a terminal.
+
+  - repo: rust-os-str-bytes
+    group: deepin-sysdev-team
+    info: Utilities for converting between byte sequences and platform-native strings.
+
+  - repo: rust-winapi-util
+    group: deepin-sysdev-team
+    info: Dumping ground for high level safe wrappers over winapi.
+


### PR DESCRIPTION
rust-clap, Rust Command Line Argument Parser.
rust-clap-lex, Minimal, flexible command line parser.
rust-termcolor, Simple cross platform library for writing colored text to a terminal.
rust-os-str-bytes, Utilities for converting between byte sequences and platform-native st>
rust-winapi-util, Dumping ground for high level safe wrappers over winapi.
Log: rust-clap, rust-clap-lex, rust-termcolor, rust-os-str-bytes, rust-winapi-util would >
Issue:
        https://github.com/deepin-community/sig-deepin-sysdev-team/issues/76
        https://github.com/deepin-community/sig-deepin-sysdev-team/issues/83
        https://github.com/deepin-community/sig-deepin-sysdev-team/issues/82
        https://github.com/deepin-community/sig-deepin-sysdev-team/issues/84
        https://github.com/deepin-community/sig-deepin-sysdev-team/issues/28