### PR TITLE
feat: add bpython, butt

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -866,3 +866,11 @@ repos:
     group: deepin-sysdev-team
     info: This package contains the source for the Rust lexical-core crate.
     
+  - repo: bpython
+    group: deepin-sysdev-team
+    info: fancy interface to the Python 3 interpreter
+
+  - repo: butt
+    group: deepin-sysdev-team
+    info: an easy to use, multi OS streaming tool.
+


### PR DESCRIPTION
bpython, fancy interface to the Python 3 interpreter butt, an easy to use, multi OS streaming tool.
Log: add bpython, butt
Issue:
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/87
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/88