### PR TITLE
feat: add fonts-google-noto-sans-simplified-chinese,iotop,exim4

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -878,3 +878,14 @@ repos:
     group: deepin-sysdev-team
     info: Rust crate that provides bindings for libclang, the C interface to the Clang compiler.
 
+  - repo: fonts-google-noto-sans-simplified-chinese
+    group: deepin-sysdev-team
+    info: Noto Sans SC is an unmodulated (“sans serif”) design for languages in mainland China that use the Simplified Chinese variant of the Han ideograms.
+
+  - repo: iotop
+    group: deepin-sysdev-team
+    info: simple top-like I/O monitor
+
+  - repo: exim4
+    group: deepin-sysdev-team
+    info: metapackage to ease Exim MTA (v4) installation


### PR DESCRIPTION
fonts-google-noto-sans-simplified-chinese, Noto Sans SC is an unmodulated (“sans serif”) design for languages in mainland China that use the Simplified Chinese variant of the Han ideograms.

iotop, simple top-like I/O monitor

exim4, metapackage to ease Exim MTA (v4) installation

Log: add fonts-google-noto-sans-simplified-chinese,iotop,exim4

Issue:

deepin-community/sig-deepin-sysdev-team#85

deepin-community/sig-deepin-sysdev-team#86

deepin-community/sig-deepin-sysdev-team#89