### PR TITLE
feat: add rust-clang-sys

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -874,3 +874,7 @@ repos:
     group: deepin-sysdev-team
     info: an easy to use, multi OS streaming tool.
 
+  - repo: rust-clang-sys
+    group: deepin-sysdev-team
+    info: Rust crate that provides bindings for libclang, the C interface to the Clang compiler.
+


### PR DESCRIPTION
Rust crate that provides bindings for libclang, the C interface to the Clang compiler.

Log: add rust-clang-sys
Issue: deepin-community/sig-deepin-sysdev-team#90