### PR TITLE
feat: add rust-cfg-if-1.0

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -874,3 +874,6 @@ repos:
     group: deepin-sysdev-team
     info: an easy to use, multi OS streaming tool.
 
+  - repo: rust-cfg-if-1.0
+    group: deepin-sysdev-team
+    info: This metapackage enables feature "core" for the Rust cfg-if crate, by pulling in any additional dependencies needed by that feature.


### PR DESCRIPTION
This metapackage enables feature "core" for the Rust cfg-if crate, by pulling in any additional dependencies needed by that feature.

Log: add rust-cfg-if-1.0
Issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/95
Task: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/95
Influence: fonts rust-cfg-if-1.0 would be added