### PR TITLE
feat: add nss-pem

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -926,3 +926,7 @@ repos:
     group: deepin-sysdev-team
     info: These are various tools for manipulating JET / MS Access database (MDB) files.
 
+  - repo: nss-pem
+    group: deepin-sysdev-team
+    info: This package provides a PEM file reader for Network Security Services (NSS), implemented as a PKCS#11 module.
+


### PR DESCRIPTION
This package provides a PEM file reader for Network Security Services (NSS), implemented as a PKCS#11 module.

Log: add nss-pem
Issues: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/156