### PR TITLE
feat: add debian-keyring

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -942,3 +942,7 @@ repos:
     group: deepin-sysdev-team
     info: the Tuffy Truetype Font Family
 
+  - repo: debian-keyring
+    group: deepin-sysdev-team
+    info: The Debian project wants developers to digitally sign the announcements of their packages with GnuPG, to protect against forgeries. This package contains keyrings of GnuPG and keys of Debian Developers (uploading and non-uploading), as well as of Debian Maintainers.
+


### PR DESCRIPTION
The Debian project wants developers to digitally sign the announcements of their packages with GnuPG, to protect against forgeries. This package contains keyrings of GnuPG and keys of Debian Developers (uploading and non-uploading), as well as of Debian Maintainers.

Log: add debian-keyring
Issue: deepin-community/sig-deepin-sysdev-team#163