### PR TITLE
feat: add rust-compiler-builtins, rust-rustc-std-workspace-core

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1074,3 +1074,11 @@ repos:
     group: deepin-sysdev-team
     info: Command line interface Parsing library.
 
+  - repo: rust-compiler-builtins
+    group: deepin-sysdev-team
+    info: Compiler intrinsics used by the Rust compiler
+
+  - repo: rust-rustc-std-workspace-core
+    group: deepin-sysdev-team
+    info: Explicitly empty crate for rust-lang/rust integration
+


### PR DESCRIPTION
Compiler intrinsics used by the Rust compiler
Explicitly empty crate for rust-lang/rust integration

Log: add rust-compiler-builtins, rust-rustc-std-workspace-core
Issue: deepin-community/sig-deepin-sysdev-team#111,deepin-community/sig-deepin-sysdev-team#113