### PR TITLE
feat: add hexchat, xcvt, xserver-xorg, libss

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1058,3 +1058,19 @@ repos:
     group: deepin-sysdev-team
     info: It is a library for parsing, compiling, and executing regular expressions.
 
+  - repo: hexchat
+    group: deepin-sysdev-team
+    info: IRC client for X based on X-Chat 2.
+
+  - repo: xcvt
+    group: deepin-sysdev-team
+    info: library for SSA/ASS subtitles rendering.
+
+  - repo: xserver-xorg
+    group: deepin-sysdev-team
+    info: Xorg X server - core server: This package is built from the X.org xserver module.
+
+  - repo: libss
+    group: deepin-sysdev-team
+    info: Command line interface Parsing library.
+


### PR DESCRIPTION
hexchat: IRC client for X based on X-Chat 2: HexChat is a graphical IRC client with a GTK+ GUI. 

xcvt: library for SSA/ASS subtitles rendering.

xserver-xorg: Xorg X server - core server: This package is built from the X.org xserver module. 

libss: Command line interface Parsing library.

log: add hexchat, xcvt, xserver-xorg, libss
issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/169 https://github.com/deepin-community/sig-deepin-sysdev-team/issues/181 https://github.com/deepin-community/sig-deepin-sysdev-team/issues/183 https://github.com/deepin-community/sig-deepin-sysdev-team/issues/189