### PR TITLE
feat: add rust-serde, rust-arbitrary

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1014,3 +1014,11 @@ repos:
     group: deepin-sysdev-team
     info: the source for the Rust void crate
     
+  - repo: rust-serde
+    group: deepin-sysdev-team
+    info: a framework for serializing and deserializing Rust data structures efficiently and generically.
+    
+  - repo: rust-arbitrary
+    group: deepin-sysdev-team
+    info: The Arbitrary crate lets you construct arbitrary instances of a type.
+    


### PR DESCRIPTION
rust-serde, a framework for serializing and deserializing Rust data structures efficiently and generically. rust-arbitrary, the Arbitrary crate lets you construct arbitrary instances of a type. Log: add rust-serde, rust-arbitrary
Issue:
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/164 https://github.com/deepin-community/sig-deepin-sysdev-team/issues/165