### PR TITLE
feat: add isochron, ktx, mctc-lib, distance, libtpms

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1090,3 +1090,23 @@ repos:
     group: deepin-sysdev-team
     info: Portable Extensible Toolkit for Scientific Computation
 
+  - repo: isochron
+    group: deepin-sysdev-team
+    info: A real-time application for testing Time Sensitive Networking equipment.
+
+  - repo: ktx
+    group: deepin-sysdev-team
+    info: A popular QuakeWorld server modification, adding numerous features to the core features of the server.
+
+  - repo: mctc-lib
+    group: deepin-sysdev-team
+    info: A modular computation tool chain library (development files)
+
+  - repo: distance
+    group: deepin-sysdev-team
+    info: A Python library for comparing sequences
+
+  - repo: libtpms
+    group: deepin-sysdev-team
+    info: A library that provides TPM functionality
+


### PR DESCRIPTION
The isochron program is a real-time application for testing Time Sensitive Networking equipment. 
KTX (Kombat Teams eXtreme) is a popular QuakeWorld server modification, adding numerous features to the core features of the server. 
mctc-lib is a modular computation tool chain library (development files) 
distance is a Python library for comparing sequences 
Libtpms is a library that provides TPM functionality. Libtpm is used by swtpm package.

Log: add isochron, ktx, mctc-lib, distance, libtpms 
Issue:
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/160 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/161 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/190 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/191 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/194