### PR TITLE
feat: add java-sip-api, libsis-base-java, libsis-jhdf5-java, sitemesh

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1110,3 +1110,19 @@ repos:
     group: deepin-sysdev-team
     info: A library that provides TPM functionality
 
+  - repo: java-sip-api
+    group: deepin-sysdev-team
+    info: SIP API for Java
+
+  - repo: libsis-base-java
+    group: deepin-sysdev-team
+    info: Base libraries used by software from the SIS division at ETH Zurich
+
+  - repo: libsis-jhdf5-java
+    group: deepin-sysdev-team
+    info: easy-to-use HDF library for Java
+
+  - repo: sitemesh 
+    group: deepin-sysdev-team
+    info: web-page layout and decoration framework
+


### PR DESCRIPTION
SIP API for Java
Base libraries used by software from the SIS division at ETH Zurich 
easy-to-use HDF library for Java
web-page layout and decoration framework

Log: add java-sip-api, libsis-base-java, libsis-jhdf5-java, sitemesh
Issue: deepin-community/sig-deepin-sysdev-team#195,deepin-community/sig-deepin-sysdev-team#196,deepin-community/sig-deepin-sysdev-team#197,deepin-community/sig-deepin-sysdev-team#198