### PR TITLE
feat: add paperwork,libinsane,pycountry,python-pyocr,libpillowfight

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1250,3 +1250,23 @@ repos:
     group: deepin-sysdev-team
     info: The socket program is a simple tool for socket based connections. It can be used to create simple daemons (in both standalone and inetd mode), to connect to other daemons or to redirect ports.
 
+  - repo: paperwork
+    group: deepin-sysdev-team
+    info: Paperwork is a personal document manager
+
+  - repo: libinsane
+    group: deepin-sysdev-team
+    info: Library to access scanner
+
+  - repo: pycountry
+    group: deepin-sysdev-team
+    info: ISO databases accessible from Python 3
+  
+  - repo: python-pyocr
+    group: deepin-sysdev-team
+    info: Python wrapper for OCR engines (Python 3)
+
+  - repo: libpillowfight 
+    group: deepin-sysdev-team
+    info: Python 3 bindings for libpillowfight
+


### PR DESCRIPTION
Paperwork is a personal document manager.
Library to access scanner
ISO databases accessible from Python 3
Python wrapper for OCR engines (Python 3)
Python 3 bindings for libpillowfight

Log: add paperwork,libinsane,pycountry,python-pyocr,libpillowfight
Issue: deepin-community/sig-deepin-sysdev-team#231,deepin-community/sig-deepin-sysdev-team#232,deepin-community/sig-deepin-sysdev-team#233,deepin-community/sig-deepin-sysdev-team#234,deepin-community/sig-deepin-sysdev-team#235