### PR TITLE
feat: add rust-syn-1, rust-derive-arbitrary, rust-smallvec

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1286,3 +1286,15 @@ repos:
     group: deepin-sysdev-team
     info: Reading/writing numbers in big-endian and little-endian.
 
+  - repo: rust-syn-1
+    group: deepin-sysdev-team
+    info: This package contains the source for the Rust syn crate, packaged by debcargo for use with cargo and dh-cargo.
+
+  - repo: rust-derive-arbitrary
+    group: deepin-sysdev-team
+    info: This package contains the source for the Rust derive_arbitrary crate, packaged by debcargo for use with cargo and dh-cargo.
+
+  - repo: rust-smallvec
+    group: deepin-sysdev-team
+    info: This package contains the source for the Rust smallvec crate, packaged by debcargo for use with cargo and dh-cargo.
+


### PR DESCRIPTION
This package contains the source for the Rust syn crate This package contains the source for the Rust derive_arbitrary crate This package contains the source for the Rust smallvec crate

Log: add rust-syn-1, rust-derive-arbitrary, rust-smallvec
Issue: deepin-community/sig-deepin-sysdev-team#214, deepin-community/sig-deepin-sysdev-team#215, deepin-community/sig-deepin-sysdev-team#221