### PR TITLE
feat: add rust-humantime, rust-device-tree

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1298,3 +1298,11 @@ repos:
     group: deepin-sysdev-team
     info: This package contains the source for the Rust smallvec crate, packaged by debcargo for use with cargo and dh-cargo.
 
+  - repo: rust-humantime
+    group: deepin-sysdev-team
+    info: Parser and formatter for std::time::{Duration, SystemTime}
+    
+  - repo: rust-device-tree
+    group: deepin-sysdev-team
+    info: Reads and parses Linux device tree images
+    


### PR DESCRIPTION
rust-humantime, Parser and formatter for std::time::{Duration, SystemTime} 
rust-device-tree, Reads and parses Linux device tree images Log: add rust-humantime, rust-device-tree
Issue:
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/32 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/255