### PR TITLE
feat: add mate-submodules, gla11y, pluma

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1306,3 +1306,15 @@ repos:
     group: deepin-sysdev-team
     info: Reads and parses Linux device tree images
     
+  - repo: mate-submodules
+    group: deepin-sysdev-team
+    info: MATE code components provided as Git submodule repository
+
+  - repo: gla11y
+    group: deepin-sysdev-team
+    info: Automatic check of accessibility of .ui files
+
+  - repo: pluma
+    group: deepin-sysdev-team
+    info: official text editor of the MATE desktop environment
+


### PR DESCRIPTION
mate-submodules: MATE code components provided as Git submodule repository
gla11y:  Automatic check of accessibility of .ui files
pluma: official text editor of the MATE desktop environment

Log: add mate-submodules, gla11y, pluma
Issue:
deepin-community/sig-deepin-sysdev-team#257
deepin-community/sig-deepin-sysdev-team#258
deepin-community/sig-deepin-sysdev-team#259