### PR TITLE
feat: add bird, bird2, babeld, base16384, btop

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1358,3 +1358,23 @@ repos:
     group: deepin-sysdev-team
     info: C++ representation of 2D and 3D vectors and matrices and other simple but usefulmathematical objects
 
+  - repo: babeld
+    group: deepin-sysdev-team
+    info: loop-free distance-vector routing protocol
+
+  - repo: bird2
+    group: deepin-sysdev-team
+    info: Internet routing daemon with full support for all the major routing protocols
+
+  - repo: bird
+    group: deepin-sysdev-team
+    info: Internet routing daemon with full support for all the major routing protocols
+
+  - repo: base16384
+    group: deepin-sysdev-team
+    info: Encode binary files to printable utf16be
+
+  - repo: btop
+    group: deepin-sysdev-team
+    info: Modern and colorful command line resource monitor that shows usage and stats
+


### PR DESCRIPTION
Add `bird`, `bird2`, `babeld`, `base16384`, `btop`
---
`bird`: BIRD Internet Routing Daemon, version 1.x
`bird2`: BIRD Internet Routing Daemon, version 2.x
`babeld`: Routing daemon using babel protocol
`base16384`: Encode binary files to printable utf16be
`btop`: Modern and colorful command line resource monitor that shows usage and stats