### PR TITLE
feat: add rust-no-panic

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1378,3 +1378,6 @@ repos:
     group: deepin-sysdev-team
     info: Modern and colorful command line resource monitor that shows usage and stats
 
+  - repo: rust-no-panic
+    group: deepin-sysdev-team
+    info: Attribute macro to require a function can't ever panic


### PR DESCRIPTION
Attribute macro to require a function can't ever panic.

Log: rust-no-panic would be added.

Issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/144