### PR TITLE
feat: add libspnav, log4cplus, imath

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1382,3 +1382,15 @@ repos:
     group: deepin-sysdev-team
     info: Simulate bouncing balls in a window
 
+  - repo: libspnav
+    group: deepin-sysdev-team
+    info: provides alternative to the proprietary 3Dconnexion SDK for their 3D input devices
+
+  - repo: log4cplus
+    group: deepin-sysdev-team
+    info: C++ logging API providing control over log management and configuration.
+
+  - repo: imath
+    group: deepin-sysdev-team
+    info: C++ representation of 2D and 3D vectors and matrices and other objects
+


### PR DESCRIPTION
The spacenav project provides a free, compatible alternative to the proprietary 3Dconnexion SDK for their 3D input devices 
log4cplus is a simple to use C++ logging API providing thread-safe, flexible, and arbitrarily granular control over log management and configuration. 
Imath is a basic, light-weight, and efficient C++ representation of 2D and 3D vectors and matrices and other simple but usefulmathematical objects, functions, and data types common in computer graphics applications, including the “half” 16-bit floating-point type.

Log: add libspnav, log4cplus, imath
Issue:
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/245 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/256 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/263