### PR TITLE
feat: add rust-hashbrown and rust-once-cell

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1473,3 +1473,12 @@ repos:
   - repo: arp-scan
     group: deepin-sysdev-team
     info: arp scanning and fingerprinting tool
+
+  - repo: rust-hashbrown
+    group: deepin-sysdev-team
+    info: Rust port of Google's SwissTable hash map.
+
+  - repo: rust-once-cell
+    group: deepin-sysdev-team
+    info: Attribute macro to require a function can't ever panic.
+


### PR DESCRIPTION
rust-hashbrown,rust port of Google's SwissTable hash map.
rust-once-cell,attribute macro to require a function can't ever panic.

Log: rust-hashbrown and rust-once-cell would be added.

Issue: 
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/109
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/145