### PR TITLE
feat: add ipp-usb, evilwm, python-arrow, python-exif, python-pefile

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1414,3 +1414,23 @@ repos:
     group: deepin-sysdev-team
     info: Material Design Icons DX
 
+  - repo: ipp-usb
+    group: deepin-sysdev-team
+    info: ipp-usb is a userland driver for USB devices supporting the IPP over USB protocol.
+
+  - repo: evilwm
+    group: deepin-sysdev-team
+    info: evilwm is based on aewm by Decklin Foster.
+
+  - repo: python-arrow
+    group: deepin-sysdev-team
+    info: python-arrow is a Python3 library to manipulate dates, times, and timestamps
+
+  - repo: python-exif
+    group: deepin-sysdev-team
+    info: python-exif is a Python library to extract Exif information from digital camera image files.
+
+  - repo: python-pefile
+    group: deepin-sysdev-team
+    info: pefile is a Python module to read and work with Portable Executable (PE) files.
+


### PR DESCRIPTION
ipp-usb is a userland driver for USB devices supporting the IPP over USB protocol. 
evilwm is based on aewm by Decklin Foster.
python-arrow is a Python3 library to manipulate dates, times, and timestamps.
python-exif is a Python library to extract Exif information from digital camera image files. 
pefile is a Python module to read and work with Portable Executable (PE) files.

Log: add ipp-usb, evilwm, python-arrow, python-exif, python-pefile 
Issue:
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/287 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/293 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/256 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/298 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/300