### PR TITLE
feat: add libabigail

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1529,3 +1529,8 @@ repos:
   - repo: wlroots-git
     group: deepin-sysdev-team
     info: A modular Wayland compositor library. git version.
+
+  - repo: libabigail
+    group: deepin-sysdev-team
+    info: This is an interface to the GNU Compiler Collection for the collection and analysis of compiler-generated binaries.
+


### PR DESCRIPTION
This is an interface to the GNU Compiler Collection for the collection and analysis of compiler-generated binaries.

Log: add libabigail
Issue: deepin-community/sig-deepin-sysdev-team#315