### PR TITLE
feat: add fonts-arundina,fonts-mlym,fonts-uralic,fonts-arphic-ukai,fonts-material-design-icons-iconfont

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1398,22 +1398,6 @@ repos:
     group: deepin-sysdev-team
     info: Thai DejaVu-compatible fonts
 
-  - repo: fonts-mlym
-    group: deepin-sysdev-team
-    info: Meta package to install all Malayalam fonts
-
-  - repo: fonts-uralic
-    group: deepin-sysdev-team
-    info: Truetype fonts for Cyrillic-based Uralic languages
-
-  - repo: fonts-arphic-ukai
-    group: deepin-sysdev-team
-    info: AR PL UKai Chinese Unicode TrueType font collection Kaiti style
-
-  - repo: fonts-material-design-icons-iconfont
-    group: deepin-sysdev-team
-    info: Material Design Icons DX
-
   - repo: ipp-usb
     group: deepin-sysdev-team
     info: ipp-usb is a userland driver for USB devices supporting the IPP over USB protocol.
@@ -1569,4 +1553,20 @@ repos:
   - repo: golang-github-go-macaron-inject
     group: deepin-sysdev-team
     info: utilities for mapping and injecting dependencies
+
+  - repo: fonts-mlym
+    group: deepin-sysdev-team
+    info: Meta package to install all Malayalam fonts
+
+  - repo: fonts-uralic
+    group: deepin-sysdev-team
+    info: Truetype fonts for Cyrillic-based Uralic languages
+
+  - repo: fonts-arphic-ukai
+    group: deepin-sysdev-team
+    info: AR PL UKai Chinese Unicode TrueType font collection Kaiti style
+
+  - repo: fonts-material-design-icons-iconfont
+    group: deepin-sysdev-team
+    info: Material Design Icons DX
 


### PR DESCRIPTION
Custom icon webfonts from the comfort of the command line

Thai DejaVu-compatible fonts

Meta package to install all Malayalam fonts

Truetype fonts for Cyrillic-based Uralic languages

"AR PL UKai" Chinese Unicode TrueType font collection Kaiti style

Fork of the iconic font and CSS toolkit

Material Design Icons DX

Log: add fonts-arundina,fonts-mlym,fonts-uralic,fonts-arphic-ukai,fonts-material-design-icons-iconfont 
Issues:deepin-community/sig-deepin-sysdev-team#266 
Issues:deepin-community/sig-deepin-sysdev-team#267 
Issues:deepin-community/sig-deepin-sysdev-team#268 
Issues:deepin-community/sig-deepin-sysdev-team#269 
Issues:deepin-community/sig-deepin-sysdev-team#271