### PR TITLE
feat: add rust-itoa, rust-once-cell, rust-erased-serde, rust-serde-fm…

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1574,3 +1574,47 @@ repos:
     group: deepin-sysdev-team
     info: GNOME library to manage keyboard configuration
 
+  - repo: rust-itoa
+    group: deepin-sysdev-team
+    info: Fast functions printing integer primitives to io::Write.s
+
+  - repo: rust-once-cell
+    group: deepin-sysdev-team
+    info: Attribute macro to require a function can't ever panic.
+
+  - repo: rust-erased-serde
+    group: deepin-sysdev-team
+    info: Type-erased Serialize and Serializer traits.
+
+  - repo: rust-serde-fmt
+    group: deepin-sysdev-team
+    info: write any serde::Serialize using standard formatting APIs.
+
+  - repo: rust-ctor
+    group: deepin-sysdev-team
+    info: __attribute__((constructor)) for Rust.
+
+  - repo: rust-value-bag
+    group: deepin-sysdev-team
+    info: Anonymous structured values.
+
+  - repo: rust-sval-derive
+    group: deepin-sysdev-team
+    info: Custom derive for sval.
+
+  - repo: rust-sval
+    group: deepin-sysdev-team
+    info: This metapackage enables feature "sval_derive" for the Rust sval crate.
+
+  - repo: rust-ppv-lite86
+    group: deepin-sysdev-team
+    info: crypto-simd API for x86.
+
+  - repo: rust-rand-core
+    group: deepin-sysdev-team
+    info: Core random number generator traits and tools.
+
+  - repo: rust-rand-chacha
+    group: deepin-sysdev-team
+    info: ChaCha random number generator.
+


### PR DESCRIPTION
…t, rust-ctor, rust-value-bag, rust-sval-derive, rust-sval, rust-ppv-lite86, rust-rand-core, rust-rand-chacha

rust-itoa, rust-once-cell, fast functions printing integer primitives to io::Write.s rust-once-cell,attribute macro to require a function can not ever panic. rust-erased-serde, type-erased Serialize and Serializer traits. rust-serde-fmt, write any serde::Serialize using standard formatting APIs. rust-ctor, __attribute__((constructor)) for Rust.
rust-value-bag, anonymous structured values.
rust-sval-derive, custom derive for sval.
rust-sval, this metapackage enables feature ssval_derive for the Rust sval crate. rust-ppv-lite86, crypto-simd API for x86.
rust-rand-core, core random number generator traits and tools. rust-rand-chacha, ChaCha random number generator.

Log: rust-itoa, rust-erased-serde, rust-serde-fmt, rust-ctor, rust-value-bag, rust-sval-derive, rust-sval, rust-ppv-lite86, rust-rand-core, rust-rand-chacha would be added.

Issue:
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/319
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/145
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/321
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/320
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/318
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/325
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/323
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/322
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/326
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/307
	https://github.com/deepin-community/sig-deepin-sysdev-team/issues/306