### PR TITLE
feat: add jpeginfo

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -575,6 +575,10 @@ repos:
     group: deepin-sysdev-team
     info: SIP API for Java
 
+  - repo: jpeginfo
+    group: deepin-sysdev-team
+    info: jpeginfo can be used to generate informative listings of jpeg files.
+
   - repo: jtreg6
     group: deepin-sysdev-team
     info: Regression Test Harness for the OpenJDK platform


### PR DESCRIPTION
jpeginfo can be used to generate informative listings of jpeg files.

Log: add jpeginfo
Issue: deepin-community/sig-deepin-sysdev-team#388