### PR TITLE
feat: add arping,speedtest-cli,plocate,plzip,ncftp,memtester,arp-scan

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1430,34 +1430,6 @@ repos:
     group: deepin-sysdev-team
     info: Efficient full-featured X11 terminal emulator
 
-  - repo: arping
-    group: deepin-sysdev-team
-    info: sends IP and/or ARP pings (to the MAC address)
-
-  - repo: speedtest-cli
-    group: deepin-sysdev-team
-    info: Command line interface for testing internet bandwidth using speedtest.net
-
-  - repo: plocate
-    group: deepin-sysdev-team
-    info: much faster locate
-
-  - repo: plzip
-    group: deepin-sysdev-team
-    info: parallel, lossless data compressor based on the LZMA algorithm
-
-  - repo: ncftp
-    group: deepin-sysdev-team
-    info: User-friendly and well-featured FTP client
-
-  - repo: memtester
-    group: deepin-sysdev-team
-    info: Utility for testing the memory subsystem
-
-  - repo: arp-scan
-    group: deepin-sysdev-team
-    info: arp scanning and fingerprinting tool
-
   - repo: rust-hashbrown
     group: deepin-sysdev-team
     info: Rust port of Google's SwissTable hash map.
@@ -1618,3 +1590,30 @@ repos:
     group: deepin-sysdev-team
     info: ChaCha random number generator.
 
+  - repo: arping
+    group: deepin-sysdev-team
+    info: sends IP and/or ARP pings (to the MAC address)
+
+  - repo: speedtest-cli
+    group: deepin-sysdev-team
+    info: Command line interface for testing internet bandwidth using speedtest.net
+
+  - repo: plocate
+    group: deepin-sysdev-team
+    info: much faster locate
+
+  - repo: plzip
+    group: deepin-sysdev-team
+    info: parallel, lossless data compressor based on the LZMA algorithm
+
+  - repo: ncftp
+    group: deepin-sysdev-team
+    info: User-friendly and well-featured FTP client
+
+  - repo: memtester
+    group: deepin-sysdev-team
+    info: Utility for testing the memory subsystem
+
+  - repo: arp-scan
+    group: deepin-sysdev-team
+    info: arp scanning and fingerprinting tool


### PR DESCRIPTION
arping, sends IP and/or ARP pings (to the MAC address)

speedtest-cli, Command line interface for testing internet bandwidth using speedtest.net

plocate, much faster locate

plzip, parallel, lossless data compressor based on the LZMA algorithm

ncftp, User-friendly and well-featured FTP client

memtester, Utility for testing the memory subsystem

arp-scan, arp scanning and fingerprinting tool

Log: add arping,speedtest-cli,plocate,plzip,ncftp,memtester,arp-scan

Issue: 

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/289

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/290

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/292

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/294

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/295

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/297

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/299