### PR TITLE
feat: add kde-dev-utils and delete xcvt, xserver-xorg-core, libss, jq

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1617,3 +1617,12 @@ repos:
   - repo: arp-scan
     group: deepin-sysdev-team
     info: arp scanning and fingerprinting tool
+
+  - repo: jq
+    group: deepin-sysdev-team
+    info: lightweight and flexible command-line JSON processor.
+
+  - repo: mc
+    group: deepin-sysdev-team
+    info: Midnight Commander - a powerful file manager.
+

--- a/repos.yml
+++ b/repos.yml
@@ -1062,18 +1062,6 @@ repos:
     group: deepin-sysdev-team
     info: IRC client for X based on X-Chat 2.
 
-  - repo: xcvt
-    group: deepin-sysdev-team
-    info: library for SSA/ASS subtitles rendering.
-
-  - repo: xserver-xorg
-    group: deepin-sysdev-team
-    info: Xorg X server - core server: This package is built from the X.org xserver module.
-
-  - repo: libss
-    group: deepin-sysdev-team
-    info: Command line interface Parsing library.
-
   - repo: rust-compiler-builtins
     group: deepin-sysdev-team
     info: Compiler intrinsics used by the Rust compiler
@@ -1618,11 +1606,11 @@ repos:
     group: deepin-sysdev-team
     info: arp scanning and fingerprinting tool
 
-  - repo: jq
-    group: deepin-sysdev-team
-    info: lightweight and flexible command-line JSON processor.
-
   - repo: mc
     group: deepin-sysdev-team
     info: Midnight Commander - a powerful file manager.
+
+  - repo: kde-dev-utils
+    group: deepin-sysdev-team
+    info: This package builds kpartloader and kuiviewer.
 


### PR DESCRIPTION
kde-dev-utils: This package builds kpartloader and kuiviewer.
The source code repositories corresponding to xcvt, xserver xorg core, libss(2) and jq already exist, which are: libxcvt, xorg-server, e2fsprogs and jq.

log: add kde-dev-utils and delete xcvt, xserver-xorg-core, libss, jq
issue:
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/349
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/238