### PR TITLE
feat: add golang-1.15 to fix snapd

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -434,6 +434,10 @@ repos:
     group: deepin-sysdev-team
     info: GNUstep Base library - common files
 
+  - repo: golang-1.15
+    group: deepin-sysdev-team
+    info: Go programming language compiler - metapackage
+
   - repo: golang-1.20
     group: deepin-sysdev-team
     info: Go programming language compiler - metapackage


### PR DESCRIPTION
Go programming language compiler - metapackage

Log: add golang-1.15 to fix snapd
Issues: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/381