### PR TITLE
feat: add libgssglue

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -803,6 +803,10 @@ repos:
     group: deepin-sysdev-team
     info: GNOME library to manage keyboard configuration
 
+  - repo: libgssglue
+    group: deepin-sysdev-team
+    info: libgssglue provides a gssapi interface, but does not implement any gssapi mechanisms itself.
+
   - repo: libhash-multivalue-perl
     group: deepin-sysdev-team
     info: module for storing multiple values per key in a hash


### PR DESCRIPTION
libgssglue provides a gssapi interface, but does not implement any gssapi mechanisms itself

Log: add libgssglue
Issue: deepin-community/sig-deepin-sysdev-team#398