### PR TITLE
feat: add python-editor, python-css-parser, python-configargparse, python-iniparse, python-utmp

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1245,6 +1245,18 @@ repos:
     group: deepin-sysdev-team
     info: characteristic is Python package with class decorators that ease the chores of implementing the most common attribute-related object protocols.
 
+  - repo: python-configargparse
+    group: deepin-sysdev-team
+    info: python-configargparse is replacement for argparse with config files and environment variables.
+
+  - repo: python-css-parser
+    group: deepin-sysdev-team
+    info: CSS parser provides utilities for parsing, serialising CSS in Python.
+
+  - repo: python-editor
+    group: deepin-sysdev-team
+    info: python-editor is a library that provides the editor module for programmatically interfacing with your system's $EDITOR.
+
   - repo: python-exif
     group: deepin-sysdev-team
     info: python-exif is a Python library to extract Exif information from digital camera
@@ -1257,6 +1269,10 @@ repos:
   - repo: python-gmpy2
     group: deepin-sysdev-team
     info: gmpy provides interfaces GMP to Python 3 for fast, unbound-precision computations
+
+  - repo: python-iniparse
+    group: deepin-sysdev-team
+    info: python-iniparse could access and modify configuration data in INI files (Python 3)
 
   - repo: python-mailer
     group: deepin-sysdev-team
@@ -1308,6 +1324,10 @@ repos:
   - repo: python-tomli-w
     group: deepin-sysdev-team
     info: lil' TOML writer for Python
+
+  - repo: python-utmp
+    group: deepin-sysdev-team
+    info: provides 3 modules to access utmp and wtmp records.
 
   - repo: python3-fontforge
     group: deepin-sysdev-team


### PR DESCRIPTION
python-editor is a library that provides the editor module for programmatically interfacing with your system's $EDITOR. CSS parser provides utilities for parsing, serialising CSS in Python. 
python-configargparse is replacement for argparse with config files and environment variables. 
python-iniparse could access and modify configuration data in INI files (Python 3) 
python-utmp provides 3 modules to access utmp and wtmp records.

Log: add python-editor, python-css-parser, python-configargparse, python-iniparse, python-utmp 
Issue:
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/416 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/419 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/421
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/428 
https://github.com/deepin-community/sig-deepin-sysdev-team/issues/447