### PR TITLE
feat: add ssh-tools,sxhkd,sm,fscrypt,empire,pngcheck,sakura

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -262,6 +262,10 @@ repos:
     info: EL is a simple language designed to meet the needs of the presentation layer
       in Java web applications.
 
+  - repo: empire
+    group: deepin-sysdev-team
+    info: war game of the century
+
   - repo: equivs
     group: deepin-sysdev-team
     info: Circumvent Debian package dependencies
@@ -454,6 +458,10 @@ repos:
   - repo: friso
     group: deepin-sysdev-team
     info: Friso is an open source high performance Chinese word splitter.
+
+  - repo: fscrypt
+    group: deepin-sysdev-team
+    info: Tool for managing Linux filesystem encryption
 
   - repo: fstrcmp
     group: deepin-sysdev-team
@@ -1272,6 +1280,10 @@ repos:
     group: deepin-sysdev-team
     info: parallel, lossless data compressor based on the LZMA algorithm
 
+  - repo: pngcheck
+    group: deepin-sysdev-team
+    info: print info and check PNG, JNG and MNG files
+
   - repo: powertop
     group: deepin-sysdev-team
     info: PowerTOP is a Linux tool to diagnose issues with power consumption and power
@@ -1875,6 +1887,10 @@ repos:
     group: deepin-pkg
     info: Safe integer operation library for C
 
+  - repo: sakura
+    group: deepin-sysdev-team
+    info: simple but powerful libvte-based terminal emulator
+
   - repo: sbuild
     group: deepin-sysdev-team
     info: Tool for building Debian binary packages from Debian sources
@@ -1895,6 +1911,10 @@ repos:
     group: deepin-sysdev-team
     info: web-page layout and decoration framework
 
+  - repo: sm
+    group: deepin-sysdev-team
+    info: Displays a short text fullscreen
+
   - repo: socket
     group: deepin-sysdev-team
     info: The socket program is a simple tool for socket based connections. It can be
@@ -1908,6 +1928,10 @@ repos:
   - repo: speedtest-cli
     group: deepin-sysdev-team
     info: Command line interface for testing internet bandwidth using speedtest.net
+
+  - repo: ssh-tools
+    group: deepin-sysdev-team
+    info: collection of various tools using sshs
 
   - repo: sshpass
     group: deepin-sysdev-team
@@ -1937,6 +1961,10 @@ repos:
     group: deepin-sysdev-team
     info: The swtpm package provides TPM emulators that listen for TPM commands on sockets,
       character devices, or CUSE devices.
+
+  - repo: sxhkd
+    group: deepin-sysdev-team
+    info: Simple X hotkey daemon
 
   - repo: synaptic
     group: deepin-sysdev-team


### PR DESCRIPTION
ssh-tools, collection of various tools using ssh

sxhkd, Simple X hotkey daemon

sm, Displays a short text fullscreen

fscrypt, Tool for managing Linux filesystem encryption

empire, war game of the century

pngcheck, print info and check PNG, JNG and MNG files

sakura, simple but powerful libvte-based terminal emulator

Log: add ssh-tools,sxhkd,sm,fscrypt,empire,pngcheck,sakura

Issue:

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/399

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/400

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/402

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/405

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/414

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/415

https://github.com/deepin-community/sig-deepin-sysdev-team/issues/431