### PR TITLE
feat: add ruby-minitar, ruby-mini-portile2

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1447,6 +1447,14 @@ repos:
     info: This simple library can read Adobe Font Metrics (afm) files and use the data
       conveniently.
 
+  - repo: ruby-mini-portile2
+    group: deepin-sysdev-team
+    info: simplistic port-like solution for developers
+
+  - repo: ruby-minitar 
+    group: deepin-sysdev-team
+    info: Provides POSIX tarchive management for Ruby
+
   - repo: ruby-nokogiri
     group: deepin-sysdev-team
     info: HTML, XML, SAX, and Reader parser for Ruby


### PR DESCRIPTION
ruby-minitar: Provides POSIX tarchive management for Ruby
ruby-mini-portile2: simplistic port-like solution for developers

Log: add ruby-minitar, ruby-mini-portile2
Issue:
deepin-community/sig-deepin-sysdev-team#460
deepin-community/sig-deepin-sysdev-team#460