### PR TITLE
fix: add apt update in workflow

### DIFF
--- a/.github/workflows/auto-create-repo.yml
+++ b/.github/workflows/auto-create-repo.yml
@@ -52,6 +52,7 @@ jobs:
             core.setOutput('app_token', token)
       - name: init osc
         run: |
+          sudo apt update
           sudo apt install osc
           mkdir ~/.config/osc
           echo "${{ secrets.OSCRC }}" > ~/.config/osc/oscrc


### PR DESCRIPTION
Failed in workflow `init osc`
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.126%2bnmu1ubuntu0.4_all.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```