### PR TITLE
feat: add a new repo

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -734,6 +734,10 @@ repos:
     group: deepin-sysdev-team
     info: SIP API for Java
 
+  - repo: jpeg-xl
+    group: deepin-sysdev-team
+    info: jpeg-xl contains a reference implementation of JPEG XL (encoder and decoder)
+
   - repo: jpeginfo
     group: deepin-sysdev-team
     info: jpeginfo can be used to generate informative listings of jpeg files.


### PR DESCRIPTION
* jpeg-xl is needed by kimageformats, which is an important package of kde.

log: add jpeg-xl