### PR TITLE
feat: add haskell-hslua-aeson

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1108,6 +1108,10 @@ repos:
     group: deepin-sysdev-team
     info: Pure Haskell commonmark parser extensions
 
+  - repo: haskell-hslua-aeson #main
+    group: deepin-sysdev-team
+    info: Allow aeson data types to be used with Lua
+
   - repo: haskell-hslua-classes #main
     group: deepin-sysdev-team
     info: Type classes for HsLua


### PR DESCRIPTION
Allow aeson data types to be used with Lua

Log: add repo