### PR TITLE
fix(CI): repos.yml排序导致的obs仓库删除

### DIFF
--- a/.github/workflows/auto-create-repo.yml
+++ b/.github/workflows/auto-create-repo.yml
@@ -168,10 +168,10 @@ jobs:
               print("create_repo url: " + url)
           try:
               data, dels = get_pr_diff()
-              for repo in dels:
-                if repo != '':
-                    print(repo)
-                    del_obs_package(repo)
+              #for repo in dels:
+              #  if repo != '':
+              #      print(repo)
+              #      del_obs_package(repo)
               for repo in data:
                 if repo != '':
                     print(repo)


### PR DESCRIPTION
去掉仓库创建流程中包含的自动删除obs仓库的流程。