### PR TITLE
feat: add deepin-lkrg

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -6535,3 +6535,7 @@ repos:
   - repo: gdb-doc
     group: deepin-sysdev-team
     info: The GNU Debugger Documentation
+
+  - repo: deepin-lkrg
+    group: Avenger-285714
+    info: deepin Linux Kernel Runtime Guard


### PR DESCRIPTION
deepin Linux Kernel Runtime Guard, fork from https://github.com/lkrg-org/lkrg