### PR TITLE
fix(CI): use old octokit version to support require

### DIFF
--- a/.github/workflows/auto-create-repo.yml
+++ b/.github/workflows/auto-create-repo.yml
@@ -24,8 +24,8 @@ jobs:
           node-version: 18
       - name: install depends for load scripts
         run: |
-          npm install @octokit/rest
-          npm install @octokit/auth-app
+          npm install @octokit/rest@19.0.13
+          npm install @octokit/auth-app@6.1.1
       - name: Get token using github-script
         id: get-token
         uses: actions/github-script@v6


### PR DESCRIPTION
新版本require存在问题,需要等https://github.com/octokit/octokit.js/pull/2665 合并才能正常