### PR TITLE
chore: Add python-openstep-plist

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -5609,6 +5609,10 @@ repos:
     group: deepin-sysdev-team
     info: python3-defaults 3.11
 
+  - repo: python-openstep-plist/ #main
+    group: deepin-sysdev-team
+    info: Parser for the "old style" OpenStep property list format
+
   - repo: python-ordered-set #main
     group: deepin-sysdev-team
     info: python3-defaults 3.11


### PR DESCRIPTION
为glyphslib依赖，同时为预装的fonts-cantarell的间接构建依赖，因此需要放到main里面