### PR TITLE
chore(repos.yml): add kernel-extras

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -3251,6 +3251,10 @@ repos:
     group: deepin-sysdev-team
     info: kdump is a mechanism to capture crash dumps for the Linux kernel.
 
+  - repo: kernel-extras
+    group: deepin-sysdev-team
+    info: Kernel tools and documentation, etc.
+
   - repo: kexec-tools
     group: deepin-sysdev-team
     info: tools to support fast kexec reboots.


### PR DESCRIPTION
This repository will handle all kernel-derived packages aside from the image, headers, and libc-dev headers, as those are handled by Uniontech's `build_kernel.sh` script.

All other components are to be derived from Debian's `linux` source package, minus the aforementioned parts. This is done because the `debian/` directory would overlap with that generated by `build_kernel.sh` => `builddeb`.

See: https://github.com/deepin-community/kernel/pull/310