### PR TITLE
chore: add python3-blessed  python3-curtsies  python3-cwcwidth

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -8262,3 +8262,14 @@ repos:
     group: deepin-sysdev-team
     info: Fast and lightweight x86/x86-64 disassembler library
 
+  - repo: python3-curtsies
+    group: deepin-sysdev-team
+    info: Curtsies is a library for interacting with the terminal.
+    
+  - repo: python3-cwcwidth
+    group: deepin-sysdev-team
+    info: This module provides functions to compute the printable length of a unicode character/string on a terminal.
+    
+  - repo: python3-blessed
+    group: deepin-sysdev-team
+    info: Blessed is a thin, practical wrapper around terminal capabilities in Python.


### PR DESCRIPTION
bpython requires python3-curtsies and python3-cwcwidth, and python3-curtsies requires python3-blessed.