### PR TITLE
chore: add python-blessed python-curtsies python-cwcwidth

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -8266,3 +8266,14 @@ repos:
     group: deepin-sysdev-team
     info: Fast and lightweight x86/x86-64 disassembler library
 
+  - repo: python-curtsies
+    group: deepin-sysdev-team
+    info: Curtsies is a library for interacting with the terminal
+    
+  - repo: python-cwcwidth
+    group: deepin-sysdev-team
+    info: This module provides functions to compute the printable length of a unicode character/string on a terminal
+    
+  - repo: python-blessed
+    group: deepin-sysdev-team
+    info: Blessed is a thin, practical wrapper around terminal capabilities in Python


### PR DESCRIPTION
bpython requires python-curtsies and python-cwcwidth, and python-curtsies requires python-blessed.