### PR TITLE
feat: add package `kwin`

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -5473,6 +5473,10 @@ repos:
     group: deepin-sysdev-team
     info: kwayland-kf5
 
+  - repo: kwin
+    group: deepin-sysdev-team
+    info: KDE window manager
+
   - repo: kwrited
     group: deepin-sysdev-team
     info:


### PR DESCRIPTION
仓库中有部分包需要来自 `kwin-dev` 的头文件导致无法构建，似乎需要对 `kwin` 进行打包并添加依赖。