### PR TITLE
chore: add qt-advanced-docking-system package

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -12142,3 +12142,6 @@ repos:
     group: deepin-sysdev-team
     info: Helper library for the PiSP hardware block
 
+  - repo: qt-advanced-docking-system #main
+    group: deepin-sysdev-team
+    info: Advanced Docking System for Qt


### PR DESCRIPTION
仓库现有此软件包但无对应repo