### PR TITLE
feat: add blueprint-compiler and zig0.15 packages

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -400,6 +400,10 @@ repos:
     group: deepin-sysdev-team
     info: Bandlimited wavetable-based oscillator plugins for LADSPA hosts
 
+  - repo: blueprint-compiler #main
+    group: deepin-sysdev-team
+    info: Compile Blueprint files to GTKBuilder XML for GNOME
+
   - repo: bm-el #main
     group: deepin-sysdev-team
     info: visual bookmarks for GNU Emacs
@@ -12021,6 +12025,10 @@ repos:
   - repo: zig0.14
     group: deepin-sysdev-team
     info: zig language version 0.14
+
+  - repo: zig0.15 #main
+    group: deepin-sysdev-team
+    info: zig language version 0.15
 
   - repo: zipiosplusplus #main
     group: deepin-sysdev-team


### PR DESCRIPTION
Add blueprint-compiler (#main) and zig0.15 (#main) package entries to repos.yml Both packages are assigned to the deepin-sysdev-team group

Log: Added blueprint-compiler and zig0.15 package entries

Influence:
1. Verify blueprint-compiler package entry is correctly placed in alphabetical order
2. Verify zig0.15 package entry is correctly placed in zig section
3. Confirm repos.yml syntax remains valid after additions

feat: 添加 blueprint-compiler 和 zig0.15 软件包

在 repos.yml 中添加 blueprint-compiler (#main) 和 zig0.15 (#main) 软件包条目 两个软件包均归属于 deepin-sysdev-team 组

Log: 添加 blueprint-compiler 和 zig0.15 软件包条目

Influence:
1. 验证 blueprint-compiler 软件包条目按字母顺序正确放置
2. 验证 zig0.15 软件包条目在 zig 分区正确放置
3. 确认添加后 repos.yml 语法仍然有效